### PR TITLE
Add start wait time control

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ seamless updates, restarts, or movements without affecting its behavior.
 
 ### Simple Stuck Detection Logic
 
-Checkrr employs two fundamental concepts to identify stuck downloads:
+Checkrr employs three fundamental concepts to identify stuck downloads:
 
 1. **Average Download Speed Threshold**: This criterion helps identify both slow and dead downloads. The average
    download speed is calculated using a straightforward formula:
@@ -32,6 +32,10 @@ Checkrr employs two fundamental concepts to identify stuck downloads:
    take excessively long. Occasionally, files may download almost completely before getting stuck. In such cases, the
    average speed threshold might take a while to identify the issue. The timeout threshold is beneficial here, as it
    marks the download as stuck if it exceeds the specified duration.
+
+3. **Download Start Wait Time**: Sometimes torrents never actually begin downloading. This setting defines how long to
+   wait for any progress after a torrent is added. If no data has been downloaded within this time, the torrent is
+   removed and retried, regardless of the regular waiting threshold for speed checks.
 
 ## Installation
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -15,6 +15,8 @@ clients:
     conditions:
       # Maximum time to wait for a torrent to start before checking its status
       waiting_threshold: 5m
+      # Maximum time to wait for the download to actually start
+      download_start_wait_time: 1m
       # Maximum time to allow a download to complete
       download_timeout_threshold: 12h
       # Minimum average download speed in bytes (200 KB/s)
@@ -37,6 +39,8 @@ clients:
     conditions:
       # Maximum time to wait for a torrent to start before checking its status
       waiting_threshold: 5m
+      # Maximum time to wait for the download to actually start
+      download_start_wait_time: 1m
       # Maximum time to allow a download to complete
       download_timeout_threshold: 18h
       # Minimum average download speed in bytes (200 KB/s)

--- a/pkg/checkrr/checkrr.go
+++ b/pkg/checkrr/checkrr.go
@@ -14,6 +14,7 @@ const (
 
 	reasonStatusNotDownloading = "Download status is not downloading"
 	reasonNotEnoughTime        = "Download started recently, threshold: %s, actual: %s"
+	reasonDownloadNotStarted   = "Download did not start within threshold: %s, actual: %s"
 	reasonDownloadTimeout      = "Download timed out, threshold: %s, actual: %s"
 	reasonSlowDownloadSpeed    = "Average speed is below %v/s: %v"
 	reasonAllGood              = "Average speed is %v/s"
@@ -79,42 +80,72 @@ func (c *CheckRR) IsDownloadStuck(download client.Download) (bool, string, error
 		return false, "", fmt.Errorf("error parsing added time: %v", err)
 	}
 
-	if c.conditions.WaitingThreshold > 0 && time.Since(addedTime) < c.conditions.WaitingThreshold {
-		return false, fmt.Sprintf(
-				reasonNotEnoughTime,
-				c.conditions.WaitingThreshold,
-				time.Since(addedTime),
-			),
-			nil
+	if stuck, reason := c.downloadNotStarted(download, addedTime); stuck {
+		return true, reason, nil
 	}
 
-	if c.conditions.DownloadTimeoutThreshold > 0 && time.Since(addedTime) > c.conditions.DownloadTimeoutThreshold {
-		return true, fmt.Sprintf(
-				reasonDownloadTimeout,
-				c.conditions.DownloadTimeoutThreshold,
-				time.Since(addedTime),
-			),
-			nil
+	if skip, reason := c.isUnderWaitingThreshold(download, addedTime); skip {
+		return false, reason, nil
 	}
 
-	avg := averageSpeed(download)
-	if c.conditions.AverageSpeedThreshold > 0 && avg < c.conditions.AverageSpeedThreshold {
-		return true, fmt.Sprintf(
-				reasonSlowDownloadSpeed,
-				bytesToHumanReadable(c.conditions.AverageSpeedThreshold),
-				bytesToHumanReadable(avg),
-			),
-			nil
+	if stuck, reason := c.downloadTimedOut(download, addedTime); stuck {
+		return true, reason, nil
 	}
 
+	if stuck, reason := c.isSlowDownload(download, addedTime); stuck {
+		return true, reason, nil
+	}
+
+	avg := averageSpeed(addedTime, download)
 	return false, fmt.Sprintf(reasonAllGood, bytesToHumanReadable(avg)), nil
 }
-func averageSpeed(download client.Download) float64 {
-	addedTime, err := time.Parse(time.RFC3339, download.Added)
-	if err != nil {
-		log.WithError(err).Error("Error parsing added time")
-		return 0
+
+func (c *CheckRR) downloadNotStarted(download client.Download, addedTime time.Time) (bool, string) {
+	if c.conditions.DownloadStartWaitTime > 0 && download.Size == download.SizeLeft && time.Since(addedTime) > c.conditions.DownloadStartWaitTime {
+		return true, fmt.Sprintf(
+				reasonDownloadNotStarted,
+				c.conditions.DownloadStartWaitTime,
+				time.Since(addedTime),
+			),
+			nil
 	}
+	return false, ""
+}
+
+func (c *CheckRR) isUnderWaitingThreshold(download client.Download, addedTime time.Time) (bool, string) {
+	if download.SizeLeft < download.Size && c.conditions.WaitingThreshold > 0 && time.Since(addedTime) < c.conditions.WaitingThreshold {
+		return true, fmt.Sprintf(
+			reasonNotEnoughTime,
+			c.conditions.WaitingThreshold,
+			time.Since(addedTime),
+		)
+	}
+	return false, ""
+}
+
+func (c *CheckRR) downloadTimedOut(download client.Download, addedTime time.Time) (bool, string) {
+	if c.conditions.DownloadTimeoutThreshold > 0 && time.Since(addedTime) > c.conditions.DownloadTimeoutThreshold {
+		return true, fmt.Sprintf(
+			reasonDownloadTimeout,
+			c.conditions.DownloadTimeoutThreshold,
+			time.Since(addedTime),
+		)
+	}
+	return false, ""
+}
+
+func (c *CheckRR) isSlowDownload(download client.Download, addedTime time.Time) (bool, string) {
+	avg := averageSpeed(addedTime, download)
+	if c.conditions.AverageSpeedThreshold > 0 && avg < c.conditions.AverageSpeedThreshold {
+		return true, fmt.Sprintf(
+			reasonSlowDownloadSpeed,
+			bytesToHumanReadable(c.conditions.AverageSpeedThreshold),
+			bytesToHumanReadable(avg),
+		)
+	}
+	return false, ""
+}
+func averageSpeed(addedTime time.Time, download client.Download) float64 {
 	return float64(download.Size-download.SizeLeft) / time.Since(addedTime).Seconds()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type ClientConfig struct {
 
 type Conditions struct {
 	WaitingThreshold         time.Duration `yaml:"waiting_threshold"`
+	DownloadStartWaitTime    time.Duration `yaml:"download_start_wait_time"`
 	DownloadTimeoutThreshold time.Duration `yaml:"download_timeout_threshold"`
 	AverageSpeedThreshold    float64       `yaml:"average_speed_threshold"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,7 @@ clients:
     host: http://example.com
     conditions:
       waiting_threshold: 10s
+      download_start_wait_time: 1m
       download_timeout_threshold: 30s
       average_speed_threshold: 1.5
     options:
@@ -46,6 +47,9 @@ log_level: debug
 
 	if client.Conditions.WaitingThreshold != 10*time.Second {
 		t.Errorf("Expected WaitingThreshold 10s, got %v", client.Conditions.WaitingThreshold)
+	}
+	if client.Conditions.DownloadStartWaitTime != time.Minute {
+		t.Errorf("Expected DownloadStartWaitTime 1m, got %v", client.Conditions.DownloadStartWaitTime)
 	}
 
 	if client.Options.KeepInClient != true {


### PR DESCRIPTION
## Summary
- add a `download_start_wait_time` option in Conditions
- check for unstarted downloads before applying the existing waiting threshold
- document the new concept in README and update example config
- test config loading with the new field
- break stuck-check logic into smaller functions

## Testing
- `go test ./...` *(fails: unable to access network to download modules)*
- `go vet ./...` *(fails: unable to access network to download modules)*