### PR TITLE
Add skipping downloads with missing `added` timestamp

### DIFF
--- a/pkg/checkrr/checkrr.go
+++ b/pkg/checkrr/checkrr.go
@@ -13,6 +13,7 @@ const (
 	statusDownloading = "downloading"
 
 	reasonStatusNotDownloading = "Download status is not downloading"
+	reasonMissingAdded         = "Skipping download because added timestamp is missing"
 	reasonNotEnoughTime        = "Download started recently, threshold: %s, actual: %s"
 	reasonDownloadTimeout      = "Download timed out, threshold: %s, actual: %s"
 	reasonSlowDownloadSpeed    = "Average speed is below %v/s: %v"
@@ -55,6 +56,10 @@ func (c *CheckRR) Check() error {
 		if err != nil {
 			return fmt.Errorf("error checking download status: %v", err)
 		}
+		if reason == reasonMissingAdded {
+			log.Warnf("Skipping download [ID: %d]: %s, Reason: %s", download.ID, download.Title, reason)
+			continue
+		}
 		if stuck {
 			stucks = append(stucks, download.ID)
 			log.Warnf("Stuck download detected [ID: %d]: %s, Reason: %s", download.ID, download.Title, reason)
@@ -72,6 +77,9 @@ func (c *CheckRR) Check() error {
 func (c *CheckRR) IsDownloadStuck(download client.Download) (bool, string, error) {
 	if download.Status != statusDownloading {
 		return false, reasonStatusNotDownloading, nil
+	}
+	if download.Added == "" {
+		return false, reasonMissingAdded, nil
 	}
 
 	addedTime, err := time.Parse(time.RFC3339, download.Added)

--- a/pkg/checkrr/checkrr.go
+++ b/pkg/checkrr/checkrr.go
@@ -13,7 +13,7 @@ const (
 	statusDownloading = "downloading"
 
 	reasonStatusNotDownloading = "Download status is not downloading"
-	reasonMissingAdded         = "Skipping download because added timestamp is missing"
+	reasonMissingAdded         = "Added timestamp is missing"
 	reasonNotEnoughTime        = "Download started recently, threshold: %s, actual: %s"
 	reasonDownloadTimeout      = "Download timed out, threshold: %s, actual: %s"
 	reasonSlowDownloadSpeed    = "Average speed is below %v/s: %v"

--- a/pkg/checkrr/checkrr.go
+++ b/pkg/checkrr/checkrr.go
@@ -1,10 +1,12 @@
 package checkrr
 
 import (
+	"errors"
 	"fmt"
+	"time"
+
 	"github.com/soheilrt/checkrr/pkg/client"
 	"github.com/soheilrt/checkrr/pkg/config"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -19,6 +21,8 @@ const (
 	reasonSlowDownloadSpeed    = "Average speed is below %v/s: %v"
 	reasonAllGood              = "Average speed is %v/s"
 )
+
+var ErrMissingAdded = errors.New(reasonMissingAdded)
 
 type ClientRR interface {
 	FetchDownloads() ([]client.Download, error)
@@ -53,12 +57,12 @@ func (c *CheckRR) Check() error {
 	stucks := []int{}
 	for _, download := range downloads {
 		stuck, reason, err := c.IsDownloadStuck(download)
-		if err != nil {
-			return fmt.Errorf("error checking download status: %v", err)
-		}
-		if reason == reasonMissingAdded {
+		if errors.Is(err, ErrMissingAdded) {
 			log.Warnf("Skipping download [ID: %d]: %s, Reason: %s", download.ID, download.Title, reason)
 			continue
+		}
+		if err != nil {
+			return fmt.Errorf("error checking download status: %v", err)
 		}
 		if stuck {
 			stucks = append(stucks, download.ID)
@@ -79,7 +83,7 @@ func (c *CheckRR) IsDownloadStuck(download client.Download) (bool, string, error
 		return false, reasonStatusNotDownloading, nil
 	}
 	if download.Added == "" {
-		return false, reasonMissingAdded, nil
+		return false, reasonMissingAdded, ErrMissingAdded
 	}
 
 	addedTime, err := time.Parse(time.RFC3339, download.Added)


### PR DESCRIPTION
This pull request adds handling of downloads that are missing an `added` timestamp. The changes ensure such downloads are skipped with clear logging.

- Added the new reason `reasonMissingAdded` to clearly represent these downloads
- Updated the `IsDownloadStuck` method to return early with the new reason if a download's `Added` field is empty, avoiding errors from parsing empty timestamps
- Modified the main check loop to skip downloads with missing `added` timestamp and log a warning, ensuring these cases are handled gracefully and visibly(!)